### PR TITLE
Exclude proto folder from .gitignore, enabling inclusion in Poetry pa…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@
 .vscode
 .coverage
 target
-**/proto
+#**/proto
 poetry.lock


### PR DESCRIPTION
This commit addresses the issue of the 'proto' folder not being included in the released up-python package