### PR TITLE
feat: support adding coverage comments to PRs from forks

### DIFF
--- a/.github/workflows/coverage-comment-pr.yml
+++ b/.github/workflows/coverage-comment-pr.yml
@@ -1,0 +1,55 @@
+name: Add coverage comment to PR
+
+on:
+  workflow_run:
+    workflows: ["Python Test and Coverage"]
+    types:
+      - completed
+
+jobs:
+  add-coverage-comment:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr-comment"
+            })[0];
+            var download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr-comment.zip', Buffer.from(download.data));
+      - run: unzip pr-comment.zip
+
+      - name: 'Comment on PR'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            var fs = require('fs');
+
+            const issue_number = Number(fs.readFileSync('./pr-number.txt'));
+            const body = fs.readFileSync('./body.txt', { encoding: 'utf8', flag: 'r' });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              body: body
+            });

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,13 +5,10 @@ on:
     branches:
       - main
 
-
 jobs:
   test-and-coverage:
     name: Test with coverage
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
 
     steps:
       - run: |
@@ -19,19 +16,10 @@ jobs:
           git config --global user.email 'uprotocol-bot@eclipse.org'
 
       - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Set up Apache Maven Central
-        uses: actions/setup-java@v3
-        with: # configure settings.xml
-          distribution: 'temurin'
-          java-version: '11'
-          server-id: ossrh
-          server-username: OSSRH_USER
-          server-password: OSSRH_PASSWORD
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: '3.x'
 
@@ -59,15 +47,41 @@ jobs:
           echo "COVERAGE_PERCENTAGE: $COVERAGE_PERCENTAGE"
           poetry run coverage html
 
-
       - name: Upload coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: coverage-report
           path: htmlcov/
 
+      - name: Generate coverage comment
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+
+            fs.mkdirSync('./pr-comment', { recursive: true });
+
+            const COVERAGE_PERCENTAGE = process.env.COVERAGE_PERCENTAGE;
+            const COVERAGE_REPORT_PATH = `https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/`;
+
+            var pr_number = `${{ github.event.number }}`;
+            var body = `
+              Code coverage report is ready! :chart_with_upwards_trend:
+
+              - **Code Coverage Percentage:** ${COVERAGE_PERCENTAGE}
+              - **Code Coverage Report:** [View Coverage Report](${COVERAGE_REPORT_PATH})
+              `;
+
+            fs.writeFileSync('./pr-comment/pr-number.txt', pr_number);
+            fs.writeFileSync('./pr-comment/body.txt', body);
+
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: pr-comment
+          path: pr-comment/
+
       - name: Check code coverage
-        uses: actions/github-script@v6
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const COVERAGE_PERCENTAGE = process.env.COVERAGE_PERCENTAGE;
@@ -77,25 +91,3 @@ jobs:
               core.info(`Success`);
               core.info(parseInt(COVERAGE_PERCENTAGE));
             }
-
-
-#      - name: Comment PR with coverage results
-#        uses: actions/github-script@v6
-#        with:
-#          github-token: ${{ secrets.GITHUB_TOKEN  }}
-#
-#          script: |
-#            const COVERAGE_PERCENTAGE = process.env.COVERAGE_PERCENTAGE;;
-#            const COVERAGE_REPORT_PATH = `https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/`;
-#             github.rest.issues.createComment({
-#              issue_number: context.issue.number,
-#              owner: context.repo.owner,
-#              repo: context.repo.repo,
-#              body: `
-#              Code coverage report is ready! :chart_with_upwards_trend:
-#
-#              - **Code Coverage Percentage:** ${COVERAGE_PERCENTAGE}
-#              - **Code Coverage Report:** [View Coverage Report](${COVERAGE_REPORT_PATH})
-#              `
-#              });
-#


### PR DESCRIPTION
This fixes #25 .

This PR add support for adding comments about code coverage to PRs coming from forks.

Additionally, the PR pins all actions and updates them to the latest available version.

I have tested these workflows in my own fork, keep in mind that this only works once the additional workflow is available in the main branch, thus after this PR has been merged.