### PR TITLE
Fix relative import issues when installing up-python

### DIFF
--- a/generate_proto.py
+++ b/generate_proto.py
@@ -40,8 +40,8 @@ def generate_all_protos():
                         '',
                         f'-I{PROTO_DIR}',
                         f'-I{PROTOBUF_INCLUDE}',
-                        f'--python_out={OUTPUT_DIR}',
-                        f'--grpc_python_out={OUTPUT_DIR}',
+                        '--python_out=.',
+                        '--grpc_python_out=.',
                         proto_file,
                     ]
                 )


### PR DESCRIPTION
**Description**
During testing of python-transport-zenoh integration with up-python, a relative import path issue was identified when installing up-python via pip.

**Issue:**

- up-python worked in local development but failed in environments using pip install . or pip install -e . due to incorrect relative imports in the module structure.
-  This blocked runtime usage of uprotocol when executing transporters and other dependent modules.

**Fix:**
* Updated relative imports to absolute imports aligned with the uprotocol package structure.

